### PR TITLE
Add Version metadata to every Table entry.

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -13,13 +13,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-<<<<<<< HEAD
-//! This crate contains the functionality needed to implement the server.
-#![feature(generators, generator_trait, asm)]
-#![warn(missing_docs)]
-=======
 #![feature(generators, generator_trait, asm, integer_atomics, atomic_min_max)]
->>>>>>> f3f5612... Add Version metadata to every Table entry.
+#![warn(missing_docs)]
 
 extern crate libloading;
 extern crate sandstorm;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -13,9 +13,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+<<<<<<< HEAD
 //! This crate contains the functionality needed to implement the server.
 #![feature(generators, generator_trait, asm)]
 #![warn(missing_docs)]
+=======
+#![feature(generators, generator_trait, asm, integer_atomics, atomic_min_max)]
+>>>>>>> f3f5612... Add Version metadata to every Table entry.
 
 extern crate libloading;
 extern crate sandstorm;


### PR DESCRIPTION
Each key has an Entry that holds a Version and a Bytes (value). The version
number is updated each time the value associated with a key is changed. If a
value for a key is deleted and then a new one is later inserted, the code
ensures that the newly inserted version is guaranteed to have a Version greater
than that of the Version that was removed.

By using these versions, code that works with the table can tell if values have
changed, which is useful for concurrency control.